### PR TITLE
fix: Duplicate task cleaning logic, identified and removed, guards en…

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 # Contributor Code of Conduct
 
-Our valuesguide us in our day-to-day interactions and decision-making. Our open source projects are no exception. Trust, respect, collaboration and transparency are core values we believe should live and breathe within our projects. Our community welcomes participants from around the world with different experiences, unique perspectives, and great ideas to share.
+Our values guide us in our day-to-day interactions and decision-making. Our open source projects are no exception. Trust, respect, collaboration and transparency are core values we believe should live and breathe within our projects. Our community welcomes participants from around the world with different experiences, unique perspectives, and great ideas to share.
 
 ## Our Pledge
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Use publish - subscriber pattern to task creeps.
 
 **Strategy**: Assign one or two dedicated miners per source with exactly 5 WORK parts each (or 10 total per source).
 
-**Bonus**: Place a container adjacent to the source for static miners to dump into, avoiding movement inefficiencies.
+**Construction**: Place a container adjacent to the source for static miners to dump into, avoiding movement inefficiencies. Keep in mind that a source has 3,000 energy, a container can hold 2,000 energy. So balancing is required to ensure energy isn't lost.
 
 ##### Creep Role Decoupling
 **Avoid**: "do-everything" creeps. Specialize:

--- a/src/managers/memoryManager.ts
+++ b/src/managers/memoryManager.ts
@@ -110,7 +110,7 @@ export function getNumberOfSourceLocations(room: Room): number
  */
 export function getRoomPhase(room: Room): RoomPhase {
   const roomMemory = getRoomMemory(room);
-  if (!roomMemory) return -1;
+  if (!roomMemory) return RoomPhase.UnitiatedRoom;
   if (!roomMemory.creeps) return 0;
   const rcl = roomMemory.rcl ?? 0;
   const hasStorage = !!room.storage;


### PR DESCRIPTION
****Fixes****

- Typo in `Code of Conduct`
- Refined ideas in `README` about container mining
- `getRoomPhase()` remove magic numbers in favour of typed `enum` for `roomPhase`
- update `taskManager` with `getRoomPhase()` logic
- remove duplicate task cleaning code