### PR TITLE
fix: Initial Bunker Builder - ensure globals are called and available…

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -24,23 +24,7 @@ export const loop = () =>
     throw new Error('Extremely low bucket - aborting script run at top level')
   }
 
-  taskManager.run();
-
-  for (const roomName in Game.rooms)
-  {
-    const room = Game.rooms[roomName];
-
-    // init memory for room
-    const memory = getRoomMemory(room);
-    if (!memory) continue;
-
-    // find and track sources
-    if (!memory.sources || Object.keys(memory.sources).length === 0) initRoom(room);
-
-    // manage spawning for each room
-    manageSpawning(room);
-  }
-
+  // setup globals
   if (!global.PLAYER_USERNAME)
   {
     global.PLAYER_USERNAME = detectPlayerUsername();
@@ -61,7 +45,26 @@ export const loop = () =>
   };
 
   if (Memory.debugVisuals?.roomName) drawDebugVisuals();
-  
+
+  taskManager.run();
+
+  for (const roomName in Game.rooms)
+  {
+    const room = Game.rooms[roomName];
+
+    // init memory for room
+    const memory = getRoomMemory(room);
+    if (!memory) continue;
+
+    // find and track sources
+    if (!memory.sources || Object.keys(memory.sources).length === 0) initRoom(room);
+
+    if (room.find(FIND_MY_CONSTRUCTION_SITES).length === 0) bunkerBuilder(roomName, 10);
+
+    // manage spawning for each room
+    manageSpawning(room);
+  }
+
   // if (Game.cpu.bucket >= 10000 && getRoomPhase(Game.rooms[0]) > 0)
   // {
   //   Game.cpu.generatePixel();

--- a/src/managers/buildingManager.ts
+++ b/src/managers/buildingManager.ts
@@ -15,7 +15,13 @@ export function bunkerBuilder(roomName: string, roomMaxlocationDistance: number)
     if (!roomMemory.spawns) return false;
     if (roomMemory.rcl < 2) return false;
 
-    const spawnPos = new RoomPosition(roomMemory.spawns[0].x, roomMemory.spawns[0].y, roomName);
+    const initalSpawn = Object.keys(roomMemory.spawns)[0];
+    if (!initalSpawn) return false;
+
+    const spawnMemory = roomMemory.spawns[initalSpawn];
+    if (!spawnMemory) return false;
+     
+    const spawnPos = new RoomPosition(spawnMemory.x, spawnMemory.y, roomName);
     const controller = Game.rooms[roomName].controller;
     let extensionAnchor: RoomPosition;
 
@@ -29,7 +35,7 @@ export function bunkerBuilder(roomName: string, roomMaxlocationDistance: number)
     for (let position of positions)
     {
         const testPos = new RoomPosition(spawnPos.x + position.x, spawnPos.y + position.y, roomName);
-        if (global.distanceTransform[roomName].get(testPos.x, testPos.y) >= 7)
+        if (global.getDistanceTransform(roomName).get(testPos.x, testPos.y) >= 7)
         {
             if (controller.pos.x - spawnPos.x === 0)
             {

--- a/src/managers/taskManager.ts
+++ b/src/managers/taskManager.ts
@@ -636,6 +636,7 @@ export const taskManager =
             const roomEnergyNetFlow = roomSustainability.getNetFlow(room);
 
             if (roomEnergyNetFlow < 0) mem.phase = RoomPhase.DeathSpiral;
+            if (mem.rcl !== room.controller?.level) mem.rcl = room.controller?.level ?? 0;
         }
 
         // Assign Tasks to Idle or Completed Creeps


### PR DESCRIPTION
… prior to building execution

<!--
Thanks for opening a pull request! Please fill out the information below so we can better understand what you're contributing.
-->

## 📋 Summary

- RCL now regularly being checked and updating
- Globals now being checked at start of main loop to ensure exists prior to other code execution
- Bunker Creation should now operate

## ✅ Related Issues / Tasks

<!-- List any related issues, bugs, or task IDs. Example: Closes #12 or Relates to task `build` -->
- Globals were being called at end of main execution loop meaning that other functions wouldn't be able to initate
- RCL never updated once initally called prevention automated progression
