### PR TITLE
fix: Bunker Builder Logic and Scanning for Construction Sites Logic

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,10 +2,10 @@
     Typescript Screeps Code for Noobs
 
     Starting 19th February 2023
-    Last Updated 9th August 2025
+    Last Updated 21st August 2025
 
-    Version:  0.0.8
-    Build:    38
+    Version:  0.0.10
+    Build:    45
 */
 
 // Import functions etc
@@ -59,7 +59,7 @@ export const loop = () =>
     // find and track sources
     if (!memory.sources || Object.keys(memory.sources).length === 0) initRoom(room);
 
-    if (room.find(FIND_MY_CONSTRUCTION_SITES).length === 0) bunkerBuilder(roomName, 10);
+    if (!memory.constructionQueue || memory.constructionQueue.length === 0) bunkerBuilder(roomName, 10);
 
     // manage spawning for each room
     manageSpawning(room);


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please fill out the information below so we can better understand what you're contributing.
-->

## 📋 Summary

Logic to reflect the two step building and intent process in screeps.

=======

## ✅ Related Issues / Tasks

- Initial steps to automated bunker creation - RCL2 5 x Extension Construction Sites previously been created, memory was updating to reflect new construction sites which meant no build tasks and no builders being generated.
- Identified that building constructions sites is a two step process, tick N the intents are created and tick N+1 the sites are created, no scaning can occur on the same tick as the intent

## 🧠 Motivation & Context

- Wanted to have working building automation

## 🔍 Changes Made

- [ ] `bunkerBuilder()` tests if construction site memory already exists
- [ ] Moved scanning constructions sites from `bunkerBuilder()` into separate `scanConstructionSites()`
- [ ] `placeConstructionSite()` now returns `ScreepResultConstant`


